### PR TITLE
Rename sort by class to be consistent

### DIFF
--- a/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctions.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctions.scala
@@ -11,7 +11,7 @@ import org.apache.spark.rdd.RDD
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-final class GroupAndSortByFunctions[K: Ordering: ClassTag, V: ClassTag](
+final class SecondarySortGroupAndSortByPairRDDFunctions[K: Ordering: ClassTag, V: ClassTag](
   rdd: RDD[(K, V)]
 ) extends Serializable {
 
@@ -472,10 +472,10 @@ final class GroupAndSortByFunctions[K: Ordering: ClassTag, V: ClassTag](
   }
 }
 
-private[sorting] object GroupAndSortByFunctions {
+private[sorting] object SecondarySortGroupAndSortByPairRDDFunctions {
   implicit def rddToGroupByAndSortFunctions[K: Ordering: ClassTag, V: ClassTag](
     rdd: RDD[(K, V)]
-  ): GroupAndSortByFunctions[K, V] = {
-    new GroupAndSortByFunctions(rdd)
+  ): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
+    new SecondarySortGroupAndSortByPairRDDFunctions(rdd)
   }
 }

--- a/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctions.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctions.scala
@@ -11,9 +11,11 @@ import org.apache.spark.rdd.RDD
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-final class SecondarySortGroupAndSortByPairRDDFunctions[K: Ordering: ClassTag, V: ClassTag](
-  rdd: RDD[(K, V)]
-) extends Serializable {
+final class SecondarySortGroupAndSortByPairRDDFunctions[
+  K: Ordering: ClassTag,
+  V: ClassTag
+](rdd: RDD[(K, V)])
+    extends Serializable {
 
   private def defaultPartitioner: Partitioner =
     Partitioner.defaultPartitioner(rdd)

--- a/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctions.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctions.scala
@@ -475,9 +475,10 @@ final class SecondarySortGroupAndSortByPairRDDFunctions[
 }
 
 private[sorting] object SecondarySortGroupAndSortByPairRDDFunctions {
-  implicit def rddToGroupByAndSortFunctions[K: Ordering: ClassTag, V: ClassTag](
-    rdd: RDD[(K, V)]
-  ): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
+  implicit def rddToSecondarySortGroupAndSortByPairRDDFunctions[
+    K: Ordering: ClassTag,
+    V: ClassTag
+  ](rdd: RDD[(K, V)]): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
     new SecondarySortGroupAndSortByPairRDDFunctions(rdd)
   }
 }

--- a/src/main/scala/net/gonzberg/spark/sorting/implicits.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/implicits.scala
@@ -26,8 +26,7 @@ object implicits {
     K: Ordering: ClassTag,
     V: ClassTag
   ](rdd: RDD[(K, V)]): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
-    SecondarySortGroupAndSortByPairRDDFunctions.rddToGroupByAndSortFunctions(
-      rdd
-    )
+    SecondarySortGroupAndSortByPairRDDFunctions
+      .rddToSecondarySortGroupAndSortByPairRDDFunctions(rdd)
   }
 }

--- a/src/main/scala/net/gonzberg/spark/sorting/implicits.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/implicits.scala
@@ -22,9 +22,12 @@ object implicits {
       .rddToSecondarySortJoiningPairRDDFunctions(rdd)
   }
 
-  implicit def rddToSecondarySortGroupAndSortByPairRDDFunctions[K: Ordering: ClassTag, V: ClassTag](
-    rdd: RDD[(K, V)]
-  ): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
-    SecondarySortGroupAndSortByPairRDDFunctions.rddToGroupByAndSortFunctions(rdd)
+  implicit def rddToSecondarySortGroupAndSortByPairRDDFunctions[
+    K: Ordering: ClassTag,
+    V: ClassTag
+  ](rdd: RDD[(K, V)]): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
+    SecondarySortGroupAndSortByPairRDDFunctions.rddToGroupByAndSortFunctions(
+      rdd
+    )
   }
 }

--- a/src/main/scala/net/gonzberg/spark/sorting/implicits.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/implicits.scala
@@ -22,9 +22,9 @@ object implicits {
       .rddToSecondarySortJoiningPairRDDFunctions(rdd)
   }
 
-  implicit def rddToGroupByAndSortFunctions[K: Ordering: ClassTag, V: ClassTag](
+  implicit def rddToSecondarySortGroupAndSortByPairRDDFunctions[K: Ordering: ClassTag, V: ClassTag](
     rdd: RDD[(K, V)]
-  ): GroupAndSortByFunctions[K, V] = {
-    GroupAndSortByFunctions.rddToGroupByAndSortFunctions(rdd)
+  ): SecondarySortGroupAndSortByPairRDDFunctions[K, V] = {
+    SecondarySortGroupAndSortByPairRDDFunctions.rddToGroupByAndSortFunctions(rdd)
   }
 }

--- a/src/test/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctionsTest.scala
+++ b/src/test/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctionsTest.scala
@@ -1,6 +1,6 @@
 package net.gonzberg.spark.sorting
 
-import GroupAndSortByFunctions.rddToGroupByAndSortFunctions
+import SecondarySortGroupAndSortByPairRDDFunctions.rddToGroupByAndSortFunctions
 import org.apache.spark.{HashPartitioner, SparkException}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +14,7 @@ object TestWrapper {
   def apply[T](value: T): TestWrapper[T] = new TestWrapper(value)
 }
 
-class GroupAndSortByFunctionsTest
+class SecondarySortGroupAndSortByPairRDDFunctionsTest
   extends AnyFunSuite
     with Matchers
     with SparkTestingMixin {

--- a/src/test/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctionsTest.scala
+++ b/src/test/scala/net/gonzberg/spark/sorting/SecondarySortGroupAndSortByPairRDDFunctionsTest.scala
@@ -1,6 +1,6 @@
 package net.gonzberg.spark.sorting
 
-import SecondarySortGroupAndSortByPairRDDFunctions.rddToGroupByAndSortFunctions
+import SecondarySortGroupAndSortByPairRDDFunctions.rddToSecondarySortGroupAndSortByPairRDDFunctions
 import org.apache.spark.{HashPartitioner, SparkException}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/net/gonzberg/spark/sorting/implicitsTest.scala
+++ b/src/test/scala/net/gonzberg/spark/sorting/implicitsTest.scala
@@ -26,7 +26,7 @@ class implicitsTest extends AnyFunSuite with Matchers with SparkTestingMixin {
     expected should contain theSameElementsInOrderAs(actual)
   }
 
-  test("GroupAndSortByFunctions implicits available") {
+  test("SecondarySortGroupAndSortByPairRDDFunctions implicits available") {
     val rdd = sc.parallelize(
       Seq("key1" ->"value1", "key1" -> "value2", "key2" -> "value1"), numSlices = 1
     )


### PR DESCRIPTION
Renames `GroupAndSortByFunctions` to `SecondarySortGroupAndSortByPairRDDFunctions` to be compatible with the other classes of this form.