### PR TITLE
Make SecondarySortGroupByKeyDatasetFunctions object private

### DIFF
--- a/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupByKeyDatasetFunctions.scala
+++ b/src/main/scala/net/gonzberg/spark/sorting/SecondarySortGroupByKeyDatasetFunctions.scala
@@ -176,7 +176,7 @@ final class SecondarySortGroupByKeyDatasetFunctions[K, V](
   }
 }
 
-object SecondarySortGroupByKeyDatasetFunctions {
+private[sorting] object SecondarySortGroupByKeyDatasetFunctions {
   implicit def datasetToSecondarySortGroupByKeyDatasetFunctions[K, V](
     dataset: Dataset[(K, V)]
   ): SecondarySortGroupByKeyDatasetFunctions[K, V] = {


### PR DESCRIPTION
The intention was for this to be package-private.